### PR TITLE
Fix event removal

### DIFF
--- a/src/main/java/com/statecore/core/EventQueue.java
+++ b/src/main/java/com/statecore/core/EventQueue.java
@@ -17,7 +17,7 @@ public class EventQueue {
         while (it.hasNext()) {
             Event ev = it.next();
             ev.handle(this.handler);
-            this.queue.remove();
+            it.remove();
         }
     }
 


### PR DESCRIPTION
## Summary
- use iterator remove when draining the event queue

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68576423fac48324ac4d1ae0f11fc145