### PR TITLE
Fix string comparison with empty string

### DIFF
--- a/src/main/java/com/statecore/core/obj/Token.java
+++ b/src/main/java/com/statecore/core/obj/Token.java
@@ -11,7 +11,7 @@ public class Token {
     public Node node;
 
     public Token(String color) {
-        if (color != null && color != "") {
+        if (color != null && !color.isEmpty()) {
             this.color = color;
         } else {
             this.color = UUID.randomUUID().toString();

--- a/src/main/java/com/statecore/core/obj/tune/CaseEl.java
+++ b/src/main/java/com/statecore/core/obj/tune/CaseEl.java
@@ -1,6 +1,5 @@
 package com.statecore.core.obj.tune;
 
-import jodd.util.StringUtil;
 
 public class CaseEl {
     private Case c;
@@ -12,8 +11,8 @@ public class CaseEl {
     }
 
     public Object getParam(String stateName, String paramName) {
-        if (stateName == null || stateName == ""
-                || paramName == null || paramName == "") {
+        if (stateName == null || stateName.isEmpty()
+                || paramName == null || paramName.isEmpty()) {
             return null;
         }
         State state = this.spec.stateNameMap.get(stateName);


### PR DESCRIPTION
## Summary
- remove unused import
- replace `== ""` and `!= ""` with `isEmpty()` checks

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576439a3d08324bec66e21bcc48590